### PR TITLE
feature/impl-change-name-to-talent-domain-model

### DIFF
--- a/src/main/kotlin/com/example/oshikara/scenarioeditor/domain/talent/Talent.kt
+++ b/src/main/kotlin/com/example/oshikara/scenarioeditor/domain/talent/Talent.kt
@@ -1,15 +1,9 @@
-package com.example.oshikara.scenarioeditor.domain
+package com.example.oshikara.scenarioeditor.domain.talent
 
 import com.example.oshikara.scenarioeditor.infrastructure.UuidGenerator
 
 data class TalentId(val value: String) {
     constructor() : this(UuidGenerator.random())
-}
-
-data class TalentName(val value: String) {
-    init {
-        // TODO ヴァリデーションを追加
-    }
 }
 
 enum class TalentStatus {
@@ -46,5 +40,9 @@ class Talent private constructor(
 
     fun private() {
         this.status = TalentStatus.PRIVATE
+    }
+
+    fun changeName(name: TalentName) {
+        this.name = name
     }
 }

--- a/src/main/kotlin/com/example/oshikara/scenarioeditor/domain/talent/TalentName.kt
+++ b/src/main/kotlin/com/example/oshikara/scenarioeditor/domain/talent/TalentName.kt
@@ -1,0 +1,15 @@
+package com.example.oshikara.scenarioeditor.domain.talent
+
+class IllegalTalentNameException(override val message: String) : Throwable()
+
+data class TalentName(val value: String) {
+    init {
+        if (value.length > TALENT_NAME_MAX_LENGTH) {
+            throw IllegalTalentNameException("名前は255文字以下で入力してください")
+        }
+    }
+
+    companion object {
+        private const val TALENT_NAME_MAX_LENGTH = 255
+    }
+}

--- a/src/main/kotlin/com/example/oshikara/scenarioeditor/domain/talent/TalentRepository.kt
+++ b/src/main/kotlin/com/example/oshikara/scenarioeditor/domain/talent/TalentRepository.kt
@@ -1,4 +1,4 @@
-package com.example.oshikara.scenarioeditor.domain
+package com.example.oshikara.scenarioeditor.domain.talent
 
 interface TalentRepository {
     fun insert(talent: Talent)

--- a/src/main/kotlin/com/example/oshikara/scenarioeditor/infrastructure/impl/domain/talent/TalentRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/oshikara/scenarioeditor/infrastructure/impl/domain/talent/TalentRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.example.oshikara.scenarioeditor.infrastructure.impl.domain.talent
 
-import com.example.oshikara.scenarioeditor.domain.Talent
-import com.example.oshikara.scenarioeditor.domain.TalentRepository
+import com.example.oshikara.scenarioeditor.domain.talent.Talent
+import com.example.oshikara.scenarioeditor.domain.talent.TalentRepository
 import com.example.oshikara.scenarioeditor.infrastructure.model.Talents
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.transactions.transaction

--- a/src/test/kotlin/com/example/oshikara/scenarioeditor/domain/talent/TalentNameTest.kt
+++ b/src/test/kotlin/com/example/oshikara/scenarioeditor/domain/talent/TalentNameTest.kt
@@ -1,0 +1,29 @@
+package com.example.oshikara.scenarioeditor.domain.talent
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class TalentNameTest {
+
+    @Test
+    fun `255文字以下だと正常にインスタンスが作成される`() {
+        val name = "a".repeat(255)
+
+        val talentName = TalentName(name)
+
+        assertEquals(name, talentName.value)
+    }
+
+    @Test
+    fun `256文字を超えてると例外が発生する`() {
+        val illegalName = "a".repeat(256)
+
+        val target: () -> Unit = {
+            TalentName(illegalName)
+        }
+
+        val exception = assertThrows<IllegalTalentNameException>(target)
+        assertEquals("名前は255文字以下で入力してください", exception.message)
+    }
+}

--- a/src/test/kotlin/com/example/oshikara/scenarioeditor/domain/talent/TalentTest.kt
+++ b/src/test/kotlin/com/example/oshikara/scenarioeditor/domain/talent/TalentTest.kt
@@ -1,4 +1,4 @@
-package com.example.oshikara.scenarioeditor.domain
+package com.example.oshikara.scenarioeditor.domain.talent
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -33,5 +33,16 @@ internal class TalentTest {
         talent.private()
 
         assertEquals(TalentStatus.PRIVATE, talent.status)
+    }
+
+    @Test
+    fun `タレントの名前を変更すると、インスタンスの名前が変更後のものになる`() {
+        val nameBeforeChangeName = TalentName("夢見 太郎")
+        val talent = Talent.create(nameBeforeChangeName)
+        val newName = TalentName("変換 ゴタロウ")
+
+        talent.changeName(newName)
+
+        assertEquals(newName, talent.name)
     }
 }

--- a/src/test/kotlin/com/example/oshikara/scenarioeditor/infrastructure/impl/domain/talent/TalentRepositoryImplTest.kt
+++ b/src/test/kotlin/com/example/oshikara/scenarioeditor/infrastructure/impl/domain/talent/TalentRepositoryImplTest.kt
@@ -1,8 +1,8 @@
 package com.example.oshikara.scenarioeditor.infrastructure.impl.domain.talent
 
-import com.example.oshikara.scenarioeditor.domain.Talent
-import com.example.oshikara.scenarioeditor.domain.TalentName
-import com.example.oshikara.scenarioeditor.domain.TalentRepository
+import com.example.oshikara.scenarioeditor.domain.talent.Talent
+import com.example.oshikara.scenarioeditor.domain.talent.TalentName
+import com.example.oshikara.scenarioeditor.domain.talent.TalentRepository
 import com.example.oshikara.scenarioeditor.infrastructure.impl.domain.TestUtil
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -34,4 +34,16 @@ internal class TalentRepositoryImplTest(
         )
         talentRepository.insert(talent)
     }
+
+//    @Test
+//    fun `タレントの名前の変更に成功する`() {
+//        val talent = Talent.create(
+//            name = TalentName("夢見 太郎")
+//        )
+//        talentRepository.insert(talent)
+//
+//        talent.changeName("変換 誤太郎")
+//        val changeNameTalent = talentRepository.update(talent)
+//
+//    }
 }


### PR DESCRIPTION
- TalentNameは255文字以内
- TalentNameを変更できる処理の追加 